### PR TITLE
refactor: use AsRef

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,7 +783,6 @@ dependencies = [
  "tar",
  "tokio-fs-ext",
  "wasm-bindgen-test",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1205,9 +1205,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-fs-ext"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18c1fdbd47c3cad0bde5dd73610c1e0b30b24ed01ed0f6918fef3bfaf41916d5"
+checksum = "ee5f304e25ab0a98c9f8bdb22a636dba8cdcd539d9db25ed33eea151781803e7"
 dependencies = [
  "bitflags",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,12 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "anyhow"
-version = "1.0.99"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -780,7 +774,6 @@ dependencies = [
 name = "opfs-project"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "flate2",
  "futures",
  "futures-util",
@@ -789,7 +782,6 @@ dependencies = [
  "serde_json",
  "tar",
  "tokio-fs-ext",
- "wasm-bindgen",
  "wasm-bindgen-test",
  "web-sys",
 ]
@@ -1026,15 +1018,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "send_wrapper"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
-dependencies = [
- "futures-core",
-]
-
-[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1223,9 +1206,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-fs-ext"
-version = "0.3.9"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6fc632b256d3ac6054a8b46e1027924ce3efde269c27986b061c495df572de"
+checksum = "18c1fdbd47c3cad0bde5dd73610c1e0b30b24ed01ed0f6918fef3bfaf41916d5"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1233,8 +1216,9 @@ dependencies = [
  "js-sys",
  "pin-project-lite",
  "rustc-hash",
- "send_wrapper",
  "tokio",
+ "tokio-stream",
+ "tracing",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -1257,6 +1241,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -1325,7 +1320,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ futures = "0.3.31"
 futures-util = "0.3.31"
 reqwest = { version = "0.12.22" }
 serde_json = "1.0.140"
-tokio-fs-ext = "0.5.2"
+tokio-fs-ext = "0.5.3"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ readme = "README.md"
 exclude = [".gitignore", ".github/", "target/", "pkg/"]
 
 [dependencies]
-anyhow = "1.0.96"
 serde = { version = "1.0.219", features = ["derive"] }
 flate2 = "1.1.2"
 tar = "0.4.44"
@@ -22,12 +21,11 @@ futures = "0.3.31"
 futures-util = "0.3.31"
 reqwest = { version = "0.12.22" }
 serde_json = "1.0.140"
-tokio-fs-ext = "0.3.9"
-web-sys = { version = "0.3", features = ["console"] }
-wasm-bindgen = "0.2"
+tokio-fs-ext = "0.5.1"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
+web-sys = { version = "0.3", features = ["console"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ tokio-fs-ext = "0.5.1"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
-web-sys = { version = "0.3", features = ["console"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "A Rust library for working with the Origin Private File System (O
 repository = "https://github.com/utooland/opfs-project"
 homepage = "https://github.com/utooland/opfs-project"
 documentation = "https://docs.rs/opfs-project"
-keywords = ["wasm","opfs", "file-system", "browser", "storage"]
+keywords = ["wasm", "opfs", "file-system", "browser", "storage"]
 categories = ["wasm", "filesystem", "web-programming"]
 authors = ["elrrrrrrr <elrrrrrrr@gmail.com>"]
 readme = "README.md"
@@ -21,7 +21,7 @@ futures = "0.3.31"
 futures-util = "0.3.31"
 reqwest = { version = "0.12.22" }
 serde_json = "1.0.140"
-tokio-fs-ext = "0.5.1"
+tokio-fs-ext = "0.5.2"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -474,7 +474,7 @@ mod tests {
 
         // Test reading through the main read function
         let node_modules_file = Path::new(&package_path).join("fuse_test.txt");
-        let result = read(&node_modules_file).await.unwrap();
+        let result = crate::read(&node_modules_file).await.unwrap();
 
         assert_eq!(result, b"Fuse link test content");
     }
@@ -486,7 +486,7 @@ mod tests {
         let package_path = create_node_modules_structure(&base_path, package_name).await;
 
         // Test reading directory through the main read_dir function
-        let result = read_dir(&package_path).await.unwrap();
+        let result = crate::read_dir(&package_path).await.unwrap();
 
         assert!(!result.is_empty());
         let file_names: Vec<String> = result
@@ -502,7 +502,9 @@ mod tests {
         let base_path = create_test_dir("test-read-regular-file").await;
 
         // Test reading a regular file (not in node_modules)
-        let result = read(&Path::new(&base_path).join("test.txt")).await.unwrap();
+        let result = tokio_fs_ext::read(&Path::new(&base_path).join("test.txt"))
+            .await
+            .unwrap();
         assert_eq!(result, b"Hello, World!");
     }
 
@@ -511,7 +513,8 @@ mod tests {
         let base_path = create_test_dir("test-read-dir-regular-directory").await;
 
         // Test reading a regular directory
-        let result = read_dir(&base_path).await.unwrap();
+
+        let result = crate::read_dir(&base_path).await.unwrap();
 
         assert!(!result.is_empty());
         let file_names: Vec<String> = result

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,128 +1,31 @@
 #![cfg(all(target_family = "wasm", target_os = "unknown"))]
 
-use anyhow::Result;
+use std::{io::Result, path::{Path, PathBuf}};
 
-use wasm_bindgen::prelude::wasm_bindgen;
 
-/// Directory entry with name and type information
-#[wasm_bindgen(inspectable)]
-#[derive(Debug, Clone)]
-pub struct DirEntry {
-    #[wasm_bindgen(getter_with_clone)]
-    pub name: String,
-    #[wasm_bindgen]
-    pub r#type: DirEntryType,
-}
 
-#[wasm_bindgen]
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub enum DirEntryType {
-    File = "file",
-    Directory = "directory",
-}
+use tokio_fs_ext::DirEntry;
 
 mod fuse;
 mod package_lock;
 pub mod package_manager;
 mod util;
 
-pub mod opfs {
-    use super::*;
+pub use fuse::{read, read_dir};
 
-    /// Read file content with fuse.link support
-    pub async fn read_with_fuse_link(path: &str) -> Result<Vec<u8>> {
-        fuse::read(path).await
-    }
-
-    /// Read file content as bytes (without fuse.link support)
-    pub(crate) async fn read_without_fuse_link(path: &str) -> Result<Vec<u8>> {
-        let prepared_path = crate::util::prepare_path(path);
-        let content = tokio_fs_ext::read(&prepared_path).await?;
-        Ok(content)
-    }
-
-    /// Read directory contents with file type information and fuse.link support
-    pub async fn read_dir(path: &str) -> Result<Vec<DirEntry>> {
-        fuse::read_dir(path).await
-    }
-
-    /// Write content to file
-    pub async fn write(path: &str, content: &str) -> Result<()> {
-        // to buffer
-        let buffer = content.as_bytes();
-        tokio_fs_ext::write(path, buffer)
-            .await
-            .map_err(|e| anyhow::anyhow!("write error: {e}"))?;
-        Ok(())
-    }
-
-    /// Write binary content to file
-    pub async fn write_bytes(path: &str, content: &[u8]) -> Result<()> {
-        tokio_fs_ext::write(path, content)
-            .await
-            .map_err(|e| anyhow::anyhow!("write_bytes error: {e}"))?;
-        Ok(())
-    }
-
-    pub async fn create_dir(path: &str) -> Result<()> {
-        tokio_fs_ext::create_dir(path).await?;
-        Ok(())
-    }
-
-    pub async fn create_dir_all(path: &str) -> Result<()> {
-        tokio_fs_ext::create_dir_all(path)
-            .await
-            .map_err(|e| anyhow::anyhow!("create_dir_all error: {e}"))?;
-        Ok(())
-    }
-
-    /// Remove a file
-    pub async fn remove(path: &str) -> Result<()> {
-        tokio_fs_ext::remove_file(path).await?;
-        Ok(())
-    }
-
-    /// Remove directory and its contents
-    pub async fn remove_dir(path: &str) -> Result<()> {
-        tokio_fs_ext::remove_dir_all(path).await?;
-        Ok(())
-    }
-
-    /// Remove directory and its contents
-    pub async fn copy(src: &str, dst: &str) -> Result<()> {
-        tokio_fs_ext::copy(src, dst).await?;
-        Ok(())
-    }
-
-    /// Get canonical path
-    pub async fn canonicalize(path: &str) -> Result<String> {
-        let canonical_path = tokio_fs_ext::canonicalize(path).await?;
-        if let Some(path_str) = canonical_path.to_str() {
-            Ok(path_str.to_string())
-        } else {
-            Err(anyhow::anyhow!("Invalid path encoding"))
-        }
-    }
-
-    /// Check if file or directory exists
-    pub async fn exists(path: &str) -> Result<bool> {
-        match tokio_fs_ext::metadata(path).await {
-            Ok(_) => Ok(true),
-            Err(_) => Ok(false),
-        }
-    }
+/// Read file content as bytes (without fuse.link support)
+pub(crate) async fn read_without_fuse_link(path: &str) -> Result<Vec<u8>> {
+    let prepared_path = crate::util::prepare_path(path);
+    let content = tokio_fs_ext::read(&prepared_path).await?;
+    Ok(content)
 }
 
-pub mod cwd {
-    use std::path::PathBuf;
+/// Set current working directory
+pub fn set_cwd(path: impl AsRef<Path>) {
+    tokio_fs_ext::set_current_dir(path).unwrap();
+}
 
-    /// Set current working directory
-    pub fn set_cwd(path: PathBuf) {
-        tokio_fs_ext::set_current_dir(path).unwrap();
-    }
-
-    /// Read current working directory
-    pub fn get_cwd() -> PathBuf {
-        tokio_fs_ext::current_dir().unwrap()
-    }
+/// Read current working directory
+pub fn get_cwd() -> PathBuf {
+    tokio_fs_ext::current_dir().unwrap()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,23 +1,53 @@
 #![cfg(all(target_family = "wasm", target_os = "unknown"))]
 
-use std::{io::Result, path::{Path, PathBuf}};
-
-
-
-use tokio_fs_ext::DirEntry;
+use std::{
+    io::Result,
+    path::{Path, PathBuf},
+};
 
 mod fuse;
 mod package_lock;
 pub mod package_manager;
 mod util;
 
-pub use fuse::{read, read_dir};
+pub use tokio_fs_ext::DirEntry;
 
-/// Read file content as bytes (without fuse.link support)
-pub(crate) async fn read_without_fuse_link(path: &str) -> Result<Vec<u8>> {
-    let prepared_path = crate::util::prepare_path(path);
+/// Read file content with fuse.link support
+pub async fn read<P: AsRef<Path>>(path: P) -> Result<Vec<u8>> {
+    let path_ref = path.as_ref();
+    let prepared_path = crate::util::prepare_path(path_ref);
+
+    // Try to read through node_modules fuse link logic first
+    if let Some(content) = fuse::try_read_through_fuse_link(&prepared_path).await? {
+        return Ok(content);
+    }
+
+    // Fallback to direct read
     let content = tokio_fs_ext::read(&prepared_path).await?;
     Ok(content)
+}
+
+/// Read directory contents with file type information and fuse.link support
+pub async fn read_dir<P: AsRef<Path>>(path: P) -> Result<Vec<tokio_fs_ext::DirEntry>> {
+    let path_ref = path.as_ref();
+    let prepared_path = crate::util::prepare_path(path_ref);
+
+    // Handle node_modules fuse.link logic
+    if let Some(entries) = fuse::try_read_dir_through_fuse_link(&prepared_path).await? {
+        return Ok(entries);
+    }
+
+    // Handle direct directory reading
+    let entries = crate::util::read_dir_direct(&prepared_path).await?;
+
+    // Handle single fuse.link file case
+    if let Some(entries) =
+        fuse::try_read_dir_through_single_fuse_link(&prepared_path, &entries).await?
+    {
+        return Ok(entries);
+    }
+
+    Ok(entries)
 }
 
 /// Set current working directory
@@ -28,4 +58,44 @@ pub fn set_cwd(path: impl AsRef<Path>) {
 /// Read current working directory
 pub fn get_cwd() -> PathBuf {
     tokio_fs_ext::current_dir().unwrap()
+}
+
+pub async fn write(path: impl AsRef<Path>, content: impl AsRef<[u8]>) -> Result<()> {
+    // TODO: try fuse link first
+    tokio_fs_ext::write(path, content).await
+}
+
+pub async fn create_dir(path: impl AsRef<Path>) -> Result<()> {
+    // TODO: try fuse link first
+    tokio_fs_ext::create_dir(path).await
+}
+
+pub async fn create_dir_all(path: impl AsRef<Path>) -> Result<()> {
+    // TODO: try fuse link first
+    tokio_fs_ext::create_dir_all(path).await
+}
+
+pub async fn copy(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<u64> {
+    // TODO: try fuse link first
+    tokio_fs_ext::copy(from, to).await
+}
+
+pub async fn remove_file(path: impl AsRef<Path>) -> Result<()> {
+    // TODO: try fuse link first
+    tokio_fs_ext::remove_file(path).await
+}
+
+pub async fn remove_dir(path: impl AsRef<Path>) -> Result<()> {
+    // TODO: try fuse link first
+    tokio_fs_ext::remove_dir(path).await
+}
+
+pub async fn remove_dir_all(path: impl AsRef<Path>) -> Result<()> {
+    // TODO: try fuse link first
+    tokio_fs_ext::remove_dir_all(path).await
+}
+
+pub async fn metadata(path: impl AsRef<Path>) -> Result<tokio_fs_ext::Metadata> {
+    // TODO: try fuse link first
+    tokio_fs_ext::metadata(path).await
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,16 +50,6 @@ pub async fn read_dir<P: AsRef<Path>>(path: P) -> Result<Vec<tokio_fs_ext::DirEn
     Ok(entries)
 }
 
-/// Set current working directory
-pub fn set_cwd(path: impl AsRef<Path>) {
-    tokio_fs_ext::set_current_dir(path).unwrap();
-}
-
-/// Read current working directory
-pub fn get_cwd() -> PathBuf {
-    tokio_fs_ext::current_dir().unwrap()
-}
-
 pub async fn write(path: impl AsRef<Path>, content: impl AsRef<[u8]>) -> Result<()> {
     // TODO: try fuse link first
     tokio_fs_ext::write(path, content).await
@@ -98,4 +88,14 @@ pub async fn remove_dir_all(path: impl AsRef<Path>) -> Result<()> {
 pub async fn metadata(path: impl AsRef<Path>) -> Result<tokio_fs_ext::Metadata> {
     // TODO: try fuse link first
     tokio_fs_ext::metadata(path).await
+}
+
+/// Set current working directory
+pub fn set_cwd(path: impl AsRef<Path>) {
+    tokio_fs_ext::set_current_dir(path).unwrap();
+}
+
+/// Read current working directory
+pub fn get_cwd() -> PathBuf {
+    tokio_fs_ext::current_dir().unwrap()
 }

--- a/src/package_manager.rs
+++ b/src/package_manager.rs
@@ -1,11 +1,11 @@
-use anyhow::Result;
+use std::io::Result;
 use flate2::read::GzDecoder;
 use futures::future::join_all;
 use std::io::Read;
 use tar::Archive;
 
 use super::fuse;
-use super::opfs;
+
 use crate::package_lock::PackageLock;
 
 /// Download all tgz packages to OPFS
@@ -38,14 +38,14 @@ pub async fn install_deps(package_lock: &str) -> Result<Vec<String>> {
 
 /// Write root package.json to the project directory
 async fn ensure_package_json(project_name: &str, lock: &PackageLock) -> Result<()> {
-    if opfs::exists(&format!("{project_name}/package.json")).await? {
+    if tokio_fs_ext::metadata(&format!("{project_name}/package.json")).await.is_ok() {
         return Ok(());
     }
 
     if let Some(root_pkg) = lock.packages.get("") {
         let pkg_json = serde_json::to_string_pretty(root_pkg).unwrap_or("{}".to_string());
-        opfs::create_dir_all(&format!("{project_name}/node_modules")).await?;
-        opfs::write(&format!("{project_name}/package.json"), &pkg_json).await?;
+        tokio_fs_ext::create_dir_all(&format!("{project_name}/node_modules")).await?;
+        tokio_fs_ext::write(&format!("{project_name}/package.json"), pkg_json.as_bytes()).await?;
     }
     Ok(())
 }
@@ -76,7 +76,7 @@ async fn install_package(
     let paths = PackagePaths::new(name, tgz_url, project_name);
 
     // Check if already unpacked
-    if opfs::exists(&paths.unpacked_dir).await.unwrap_or(false) {
+    if tokio_fs_ext::metadata(&paths.unpacked_dir).await.is_ok() {
         fuse::fuse_link(&paths.unpacked_dir, &paths.unpack_dir).await?;
         return Ok(());
     }
@@ -93,19 +93,11 @@ async fn install_package(
 
 /// Get or download tgz file
 async fn get_or_download_tgz(tgz_url: &str, tgz_store_path: &str) -> Result<Vec<u8>> {
-    if opfs::exists(tgz_store_path).await.unwrap_or(false) {
-        opfs::read_without_fuse_link(tgz_store_path)
-            .await
-            .map_err(|e| anyhow::anyhow!("read cache error: {e:?}"))
+    if tokio_fs_ext::metadata(tgz_store_path).await.is_ok() {
+        crate::read_without_fuse_link(tgz_store_path).await
     } else {
-        let bytes = download_bytes(tgz_url)
-            .await
-            .map_err(|e| anyhow::anyhow!("download error: {e:?}"))?;
-
-        save_tgz(tgz_store_path, &bytes)
-            .await
-            .map_err(|e| anyhow::anyhow!("write tgz error: {e:?}"))?;
-
+        let bytes = download_bytes(tgz_url).await?;
+        save_tgz(tgz_store_path, &bytes).await?;
         Ok(bytes)
     }
 }
@@ -134,11 +126,11 @@ impl PackagePaths {
 pub async fn extract_tgz_bytes(tgz_bytes: &[u8], extract_dir: &str) -> Result<()> {
     let gz = GzDecoder::new(tgz_bytes);
     let mut archive = Archive::new(gz);
-    let entries = archive.entries()?;
+    let entries = archive.entries().map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
 
     for entry in entries {
-        let mut entry = entry?;
-        let path = entry.path()?;
+        let mut entry = entry.map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        let path = entry.path().map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
         let path_str = path.to_string_lossy().to_string();
 
         // Remove the first-level "package" directory if present
@@ -153,7 +145,7 @@ pub async fn extract_tgz_bytes(tgz_bytes: &[u8], extract_dir: &str) -> Result<()
 
         if entry.header().entry_type().is_file() {
             let mut contents = Vec::new();
-            entry.read_to_end(&mut contents)?;
+            entry.read_to_end(&mut contents).map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
             // Write the file to the output path
             save_tgz(&out_path, &contents).await?;
         }
@@ -167,15 +159,15 @@ async fn save_tgz(path: &str, bytes: &[u8]) -> Result<()> {
     if let Some(parent_dir) = std::path::Path::new(path).parent()
         && let Some(parent_str) = parent_dir.to_str()
     {
-        opfs::create_dir_all(parent_str).await?;
+        tokio_fs_ext::create_dir_all(parent_str).await?;
     }
-    opfs::write_bytes(path, bytes).await
+    tokio_fs_ext::write(path, bytes).await
 }
 
 /// Download bytes from URL
 async fn download_bytes(url: &str) -> Result<Vec<u8>> {
-    let response = reqwest::get(url).await?;
-    let bytes = response.bytes().await?;
+    let response = reqwest::get(url).await.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    let bytes = response.bytes().await.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
     Ok(bytes.to_vec())
 }
 #[cfg(test)]
@@ -281,7 +273,7 @@ mod tests {
     #[wasm_bindgen_test]
     async fn test_extract_tgz_bytes_simple() {
         let extract_dir = "/test-extract-simple".to_string();
-        crate::opfs::create_dir_all(&extract_dir).await.unwrap();
+        tokio_fs_ext::create_dir_all(&extract_dir).await.unwrap();
 
         // Create a simple tar.gz with test content
         let tgz_bytes = create_test_tgz_bytes();
@@ -290,8 +282,10 @@ mod tests {
         assert!(result.is_ok());
 
         // Verify files were extracted
-        let entries = crate::opfs::read_dir(&extract_dir).await.unwrap();
-        let file_names: Vec<String> = entries.iter().map(|e| e.name.clone()).collect();
+        let entries = crate::read_dir(&extract_dir).await.unwrap();
+        let file_names: Vec<String> = entries.iter()
+            .filter_map(|e| e.file_name().to_str().map(|s| s.to_string()))
+            .collect();
 
         assert!(file_names.contains(&"package.json".to_string()));
         assert!(file_names.contains(&"index.js".to_string()));
@@ -300,7 +294,7 @@ mod tests {
     #[wasm_bindgen_test]
     async fn test_extract_tgz_bytes_with_package_prefix() {
         let extract_dir = "/test-extract-prefix".to_string();
-        crate::opfs::create_dir_all(&extract_dir).await.unwrap();
+        tokio_fs_ext::create_dir_all(&extract_dir).await.unwrap();
 
         // Create a tar.gz with package/ prefix
         let tgz_bytes = create_test_tgz_with_package_prefix();
@@ -309,23 +303,27 @@ mod tests {
         assert!(result.is_ok());
 
         // Verify files were extracted without package/ prefix
-        let entries = crate::opfs::read_dir(&extract_dir).await.unwrap();
-        let file_names: Vec<String> = entries.iter().map(|e| e.name.clone()).collect();
+        let entries = crate::read_dir(&extract_dir).await.unwrap();
+        let file_names: Vec<String> = entries.iter()
+            .filter_map(|e| e.file_name().to_str().map(|s| s.to_string()))
+            .collect();
 
         assert!(file_names.contains(&"package.json".to_string()));
         assert!(file_names.contains(&"src".to_string()));
         assert!(!file_names.contains(&"package".to_string()));
 
         // Check that src is a directory and contains main.js
-        let src_entries = crate::opfs::read_dir(&format!("{}/src", extract_dir)).await.unwrap();
-        let src_file_names: Vec<String> = src_entries.iter().map(|e| e.name.clone()).collect();
+        let src_entries = crate::read_dir(&format!("{}/src", extract_dir)).await.unwrap();
+        let src_file_names: Vec<String> = src_entries.iter()
+            .filter_map(|e| e.file_name().to_str().map(|s| s.to_string()))
+            .collect();
         assert!(src_file_names.contains(&"main.js".to_string()));
     }
 
     #[wasm_bindgen_test]
     async fn test_extract_tgz_bytes_invalid_data() {
         let extract_dir = "/test-extract-invalid".to_string();
-        crate::opfs::create_dir_all(&extract_dir).await.unwrap();
+        tokio_fs_ext::create_dir_all(&extract_dir).await.unwrap();
 
         // Invalid tar.gz data
         let invalid_bytes = b"not a valid tar.gz file";
@@ -358,7 +356,7 @@ mod tests {
     #[wasm_bindgen_test]
     async fn test_ensure_package_json_new_project() {
         let project_name = "/test-project-new".to_string();
-        crate::opfs::create_dir_all(&project_name).await.unwrap();
+        tokio_fs_ext::create_dir_all(&project_name).await.unwrap();
 
         let lock = create_test_package_lock();
 
@@ -366,25 +364,25 @@ mod tests {
         assert!(result.is_ok());
 
         // Verify package.json was created
-        let package_json_exists = crate::opfs::exists(&format!("{}/package.json", project_name))
+        let package_json_exists = tokio_fs_ext::metadata(&format!("{}/package.json", project_name))
             .await
-            .unwrap();
+            .is_ok();
         assert!(package_json_exists);
 
         // Verify node_modules directory was created
-        let node_modules_exists = crate::opfs::exists(&format!("{}/node_modules", project_name))
+        let node_modules_exists = tokio_fs_ext::metadata(&format!("{}/node_modules", project_name))
             .await
-            .unwrap();
+            .is_ok();
         assert!(node_modules_exists);
     }
 
     #[wasm_bindgen_test]
     async fn test_ensure_package_json_existing_project() {
         let project_name = "/test-project-existing".to_string();
-        crate::opfs::create_dir_all(&project_name).await.unwrap();
+        tokio_fs_ext::create_dir_all(&project_name).await.unwrap();
 
         // Create existing package.json
-        crate::opfs::write(&format!("{}/package.json", project_name), "{}")
+        tokio_fs_ext::write(&format!("{}/package.json", project_name), "{}")
             .await
             .unwrap();
 
@@ -394,7 +392,7 @@ mod tests {
         assert!(result.is_ok());
 
         // Verify existing package.json was not overwritten
-        let content = crate::opfs::read_with_fuse_link(&format!("{}/package.json", project_name))
+        let content = crate::read(&format!("{}/package.json", project_name))
             .await
             .unwrap();
         let content_str = String::from_utf8(content).unwrap();
@@ -407,7 +405,7 @@ mod tests {
         let lock_json = serde_json::to_string(&lock).unwrap();
 
         let project_name = "/test-project-install".to_string();
-        crate::opfs::create_dir_all(&project_name).await.unwrap();
+        tokio_fs_ext::create_dir_all(&project_name).await.unwrap();
 
         let results = install_deps(&lock_json).await;
         if let Err(ref e) = results {
@@ -436,7 +434,7 @@ mod tests {
         let content = "Hello, OPFS!";
 
         // Try to write to a file
-        let result = crate::opfs::write(test_file, content).await;
+        let result = tokio_fs_ext::write(test_file, content).await;
 
         if let Err(ref e) = result {
             web_sys::console::log_1(&format!("Error in opfs::write: {:?}", e).into());

--- a/src/package_manager.rs
+++ b/src/package_manager.rs
@@ -408,9 +408,6 @@ mod tests {
         tokio_fs_ext::create_dir_all(&project_name).await.unwrap();
 
         let results = install_deps(&lock_json).await;
-        if let Err(ref e) = results {
-            web_sys::console::log_1(&format!("Error in install_deps: {:?}", e).into());
-        }
         assert!(results.is_ok());
 
         let results = results.unwrap();
@@ -435,10 +432,6 @@ mod tests {
 
         // Try to write to a file
         let result = tokio_fs_ext::write(test_file, content).await;
-
-        if let Err(ref e) = result {
-            web_sys::console::log_1(&format!("Error in opfs::write: {:?}", e).into());
-        }
 
         assert!(result.is_ok());
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -254,7 +254,8 @@ mod tests {
         // Should have at least 3 entries (file1.txt, file2.js, subdir)
         assert!(entries.len() >= 3);
 
-        let file_names: Vec<String> = entries.iter()
+        let file_names: Vec<String> = entries
+            .iter()
             .filter_map(|e| e.file_name().to_str().map(|s| s.to_string()))
             .collect();
 
@@ -318,7 +319,10 @@ mod tests {
 
         let entries = read_dir_direct(&temp_path).await.unwrap();
 
-        let file_names: Vec<String> = entries.iter().map(|e| e.file_name().to_string_lossy().to_string()).collect();
+        let file_names: Vec<String> = entries
+            .iter()
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .collect();
 
         // Should include both visible and hidden files
         assert!(file_names.contains(&"visible.txt".to_string()));
@@ -347,7 +351,10 @@ mod tests {
 
         let entries = read_dir_direct(&temp_path).await.unwrap();
 
-        let file_names: Vec<String> = entries.iter().map(|e| e.file_name().to_string_lossy().to_string()).collect();
+        let file_names: Vec<String> = entries
+            .iter()
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .collect();
 
         assert!(file_names.contains(&"file with spaces.txt".to_string()));
         assert!(file_names.contains(&"file-with-dashes.js".to_string()));

--- a/src/util.rs
+++ b/src/util.rs
@@ -49,14 +49,8 @@ pub fn prepare_path<P: AsRef<Path>>(path: P) -> std::path::PathBuf {
 /// Read directory directly without fuse.link logic
 pub async fn read_dir_direct<P: AsRef<Path>>(path: P) -> Result<Vec<tokio_fs_ext::DirEntry>> {
     let path_ref = path.as_ref();
-    let mut entries = Vec::new();
-    let mut read_dir = tokio_fs_ext::read_dir(path_ref).await?;
-
-    while let Some(entry) = read_dir.next_entry().await? {
-        entries.push(entry);
-    }
-
-    Ok(entries)
+    let read_dir = tokio_fs_ext::read_dir(path_ref).await?;
+    read_dir.collect()
 }
 
 #[cfg(test)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,5 @@
-use crate::{DirEntry, DirEntryType};
-use anyhow::Result;
+use std::io::Result;
+use std::path::Path;
 
 /// Extract package name from a path that contains node_modules
 pub fn get_package_name(path: &str) -> Option<String> {
@@ -34,41 +34,26 @@ pub fn get_package_name(path: &str) -> Option<String> {
 }
 
 /// Prepare path by resolving relative paths against current working directory
-pub fn prepare_path(path: &str) -> String {
-    if path.starts_with('/') {
-        path.to_string()
+pub fn prepare_path<P: AsRef<Path>>(path: P) -> std::path::PathBuf {
+    let path_ref = path.as_ref();
+    let path_str = path_ref.to_string_lossy();
+
+    if path_str.starts_with('/') {
+        std::path::PathBuf::from(path_str.as_ref())
     } else {
-        let cwd = crate::cwd::get_cwd();
-        let cwd = cwd.to_string_lossy();
-        format!("{cwd}/{path}")
+        let cwd = crate::get_cwd();
+        cwd.join(path_ref)
     }
 }
 
 /// Read directory directly without fuse.link logic
-pub async fn read_dir_direct(path: &str) -> Result<Vec<DirEntry>> {
+pub async fn read_dir_direct<P: AsRef<Path>>(path: P) -> Result<Vec<tokio_fs_ext::DirEntry>> {
+    let path_ref = path.as_ref();
     let mut entries = Vec::new();
-    let mut read_dir = tokio_fs_ext::read_dir(path)
-        .await
-        .map_err(|e| anyhow::anyhow!("Error reading directory: {}", e))?;
+    let mut read_dir = tokio_fs_ext::read_dir(path_ref).await?;
 
     while let Some(entry) = read_dir.next_entry().await? {
-        let entry_path = entry.path();
-
-        if let Some(name) = entry_path.file_name()
-            && let Some(name_str) = name.to_str()
-        {
-            let meta = tokio_fs_ext::metadata(&entry_path).await?;
-
-            let dir_entry = DirEntry {
-                name: name_str.to_string(),
-                r#type: if meta.is_dir() {
-                    DirEntryType::Directory
-                } else {
-                    DirEntryType::File
-                },
-            };
-            entries.push(dir_entry);
-        }
+        entries.push(entry);
     }
 
     Ok(entries)
@@ -194,7 +179,7 @@ mod tests {
 
         for path in test_cases {
             let result = prepare_path(path);
-            assert_eq!(result, path);
+            assert_eq!(result.to_string_lossy(), path);
         }
     }
 
@@ -213,18 +198,19 @@ mod tests {
 
         for relative_path in test_cases {
             let result = prepare_path(relative_path);
+            let result_str = result.to_string_lossy();
 
             // Verify that the result contains the relative path at the end
             assert!(
-                result.ends_with(relative_path),
+                result_str.ends_with(relative_path),
                 "Result '{}' should end with '{}'",
-                result,
+                result_str,
                 relative_path
             );
 
             // Verify that it's not an absolute path starting with /
             assert!(
-                !relative_path.starts_with('/') || result != relative_path,
+                !relative_path.starts_with('/') || result_str != relative_path,
                 "Relative path '{}' should be resolved to absolute path",
                 relative_path
             );
@@ -234,17 +220,18 @@ mod tests {
     #[wasm_bindgen_test]
     async fn test_prepare_path_empty() {
         let result = prepare_path("");
+        let result_str = result.to_string_lossy();
 
         // Should end with a slash since it's an empty path
         assert!(
-            result.ends_with('/'),
+            result_str.ends_with('/'),
             "Empty path should end with '/', got: {}",
-            result
+            result_str
         );
 
         // Should not be empty
         assert!(
-            !result.is_empty(),
+            !result_str.is_empty(),
             "Empty path should not result in empty string"
         );
     }
@@ -252,7 +239,7 @@ mod tests {
     #[wasm_bindgen_test]
     async fn test_read_dir_direct() {
         let temp_path = "/test-read-dir-direct".to_string();
-        crate::opfs::create_dir_all(&temp_path).await.unwrap();
+        tokio_fs_ext::create_dir_all(&temp_path).await.unwrap();
 
         // Create test files and directories
         tokio_fs_ext::write(&format!("{}/file1.txt", temp_path), b"content1")
@@ -273,7 +260,9 @@ mod tests {
         // Should have at least 3 entries (file1.txt, file2.js, subdir)
         assert!(entries.len() >= 3);
 
-        let file_names: Vec<String> = entries.iter().map(|e| e.name.clone()).collect();
+        let file_names: Vec<String> = entries.iter()
+            .filter_map(|e| e.file_name().to_str().map(|s| s.to_string()))
+            .collect();
 
         // Check for files
         assert!(file_names.contains(&"file1.txt".to_string()));
@@ -284,16 +273,18 @@ mod tests {
 
         // Verify file types
         for entry in &entries {
-            match entry.name.as_str() {
-                "file1.txt" | "file2.js" => {
-                    assert_eq!(entry.r#type, crate::DirEntryType::File);
-                    assert_ne!(entry.r#type, crate::DirEntryType::Directory);
+            if let Some(name) = entry.file_name().to_str() {
+                match name {
+                    "file1.txt" | "file2.js" => {
+                        let meta = tokio_fs_ext::metadata(entry.path()).await.unwrap();
+                        assert!(!meta.is_dir());
+                    }
+                    "subdir" => {
+                        let meta = tokio_fs_ext::metadata(entry.path()).await.unwrap();
+                        assert!(meta.is_dir());
+                    }
+                    _ => {}
                 }
-                "subdir" => {
-                    assert_ne!(entry.r#type, crate::DirEntryType::File);
-                    assert_eq!(entry.r#type, crate::DirEntryType::Directory);
-                }
-                _ => {}
             }
         }
     }
@@ -301,7 +292,7 @@ mod tests {
     #[wasm_bindgen_test]
     async fn test_read_dir_direct_empty_directory() {
         let temp_path = "/test-read-dir-empty".to_string();
-        crate::opfs::create_dir_all(&temp_path).await.unwrap();
+        tokio_fs_ext::create_dir_all(&temp_path).await.unwrap();
 
         let entries = read_dir_direct(&temp_path).await.unwrap();
 
@@ -318,7 +309,7 @@ mod tests {
     #[wasm_bindgen_test]
     async fn test_read_dir_direct_with_hidden_files() {
         let temp_path = "/test-read-dir-hidden".to_string();
-        crate::opfs::create_dir_all(&temp_path).await.unwrap();
+        tokio_fs_ext::create_dir_all(&temp_path).await.unwrap();
 
         // Create regular and hidden files
         tokio_fs_ext::write(&format!("{}/visible.txt", temp_path), b"visible")
@@ -333,7 +324,7 @@ mod tests {
 
         let entries = read_dir_direct(&temp_path).await.unwrap();
 
-        let file_names: Vec<String> = entries.iter().map(|e| e.name.clone()).collect();
+        let file_names: Vec<String> = entries.iter().map(|e| e.file_name().to_string_lossy().to_string()).collect();
 
         // Should include both visible and hidden files
         assert!(file_names.contains(&"visible.txt".to_string()));
@@ -344,7 +335,7 @@ mod tests {
     #[wasm_bindgen_test]
     async fn test_read_dir_direct_with_special_characters() {
         let temp_path = "/test-read-dir-special".to_string();
-        crate::opfs::create_dir_all(&temp_path).await.unwrap();
+        tokio_fs_ext::create_dir_all(&temp_path).await.unwrap();
 
         // Create files with special characters in names
         tokio_fs_ext::write(&format!("{}/file with spaces.txt", temp_path), b"content")
@@ -362,7 +353,7 @@ mod tests {
 
         let entries = read_dir_direct(&temp_path).await.unwrap();
 
-        let file_names: Vec<String> = entries.iter().map(|e| e.name.clone()).collect();
+        let file_names: Vec<String> = entries.iter().map(|e| e.file_name().to_string_lossy().to_string()).collect();
 
         assert!(file_names.contains(&"file with spaces.txt".to_string()));
         assert!(file_names.contains(&"file-with-dashes.js".to_string()));


### PR DESCRIPTION
* Uniformly update function signatures to use `impl AsRef<Path>` and `std::io::Result`
* Remove DirEntry declaration and consistently use built-in attributes from `tokio-fs-ext`
* Streamline exported functions by removing `opfs` and `cwd` modules